### PR TITLE
Don't initialize counter to 0.

### DIFF
--- a/aerospike/src/aerospike/counter.clj
+++ b/aerospike/src/aerospike/counter.clj
@@ -44,8 +44,6 @@
   client/Client
   (open! [this test node]
     (let [client (s/connect node)]
-      (Thread/sleep 3000) ; TODO: remove?
-      (s/put! client namespace set key {:value 0})
       (assoc this :client client)))
 
   (setup! [this test] this)


### PR DESCRIPTION
Increments on a non-existent bin will create the bin and start the count at zero making the initialization unnecessary. Also a delayed initialization after the counter updates have started can incorrectly reset the count back to zero.