### PR TITLE
fix for set workload + some formatting

### DIFF
--- a/aerospike/src/aerospike/counter.clj
+++ b/aerospike/src/aerospike/counter.clj
@@ -47,7 +47,7 @@
       (assoc this :client client)))
 
   (setup! [this test] this)
-  
+
   (invoke! [this test op]
     (s/with-errors op #{:read}
       (case (:f op)
@@ -58,7 +58,7 @@
                   (assoc op :type :ok)))))
 
   (teardown! [this test])
-
+    
   (close! [this test]
     (s/close client)))
 

--- a/aerospike/src/aerospike/pause.clj
+++ b/aerospike/src/aerospike/pause.clj
@@ -214,15 +214,14 @@
                 :checker (independent/checker (checker/set))
                 :generator gen
                 :final-generator
-                (s/derefer
-                  (delay
-                    (locking state
-                      (independent/concurrent-generator
-                        (count (:nodes test))
-                        (range (peek (:keys @state)))
-                        (fn [k]
-                          (gen/once {:type :invoke
-                                     :f    :read}))))))}
+                (delay
+                  (locking state
+                    (independent/concurrent-generator
+                      (count (:nodes test))
+                      (range (peek (:keys @state)))
+                      (fn [k]
+                        (gen/once {:type :invoke
+                                    :f    :read})))))}
      :nemesis {:nemesis           (nemesis state)
                :generator         gen
                :final-generator   (gen/concat

--- a/aerospike/src/aerospike/set.clj
+++ b/aerospike/src/aerospike/set.clj
@@ -5,15 +5,14 @@
             [jepsen [client :as client]
                     [checker :as checker]
                     [generator :as gen]
-                    [independent :as independent]]
-            [jepsen.checker.timeline :as timeline]))
+                    [independent :as independent]]))
 
 (defrecord SetClient [client namespace set]
   client/Client
   (open! [this test node]
     (assoc this :client (s/connect node)))
 
-  (setup! [this test])
+  (setup! [this test] this)
 
   (invoke! [this test op]
     (let [[k v] (:value op)]
@@ -51,21 +50,22 @@
     {:client  (set-client)
      :checker (independent/checker (checker/set))
      :generator (independent/concurrent-generator
-                  5
+                  5  ; TODO - make this dynamic to concurrency?
+                     ; -> concurrency // this value = num keys
                   (range)
                   (fn [k]
                     (swap! max-key max k)
                     (->> (range 10000)
                          (map (fn [x] {:type :invoke, :f :add, :value x}))
                          (gen/stagger 1/10))))
-     :final-generator (s/derefer
-                        (delay
+     :final-generator (delay
                           (locking keys
                             (independent/concurrent-generator
-                              5
-                              (range (inc @max-key))
+                              2  ; number of times to read each key @ end
+                              
+                              (range (inc @max-key))  ; which keys to read.
+                              
                               (fn [k]
                                 (gen/stagger 10
-                                   (s/each
-                                     (gen/once {:type :invoke
-                                                :f    :read}))))))))}))
+                                   (gen/each-thread
+                                     (gen/once {:type :invoke  :f    :read})))))))}))


### PR DESCRIPTION
Pause is closer.. 

----------------------------
Squashed Commits:
* Log information about errors on non-idempotent transactions.

* only one write and read to debug

* counter & set workloads fixed

* cleanup support, allow reads to retry (for set workload)

* remove pause references to removed support/derefer (unnecessary) for other workloads / project compilation

* fixing derefer / delay fixed single key reading, now all keys read

---------